### PR TITLE
Movie List Skeleton

### DIFF
--- a/to-do-coronavirus-edition/DataStore.swift
+++ b/to-do-coronavirus-edition/DataStore.swift
@@ -1,0 +1,9 @@
+//
+//  DataStore.swift
+//  to-do-coronavirus-edition
+//
+//  Created by Lauren Small on 8/27/20.
+//  Copyright © 2020 Lauren Small. All rights reserved.
+//
+
+import Foundation

--- a/to-do-coronavirus-edition/DetailsView.swift
+++ b/to-do-coronavirus-edition/DetailsView.swift
@@ -16,7 +16,7 @@ struct DetailsView: View {
                 Text("Hello Second View")
             }
         }
-        .navigationBarTitle("Details")
+        .navigationBarTitle("Movie Watchlist")
         .navigationBarItems(trailing: Button(action: {
             self.isShowingSheet.toggle()
         }) {

--- a/to-do-coronavirus-edition/DetailsView.swift
+++ b/to-do-coronavirus-edition/DetailsView.swift
@@ -10,7 +10,11 @@ import SwiftUI
 
 struct DetailsView: View {
     var body: some View {
-        Text("Hello Second View")
+        VStack {
+            List() {
+                Text("Hello Second View")
+            }
+        }
     }
 }
 

--- a/to-do-coronavirus-edition/DetailsView.swift
+++ b/to-do-coronavirus-edition/DetailsView.swift
@@ -9,17 +9,34 @@
 import SwiftUI
 
 struct DetailsView: View {
+    @State var isShowingSheet = false
     var body: some View {
         VStack {
             List() {
                 Text("Hello Second View")
             }
         }
+        .navigationBarTitle("Details")
+        .navigationBarItems(trailing: Button(action: {
+            self.isShowingSheet.toggle()
+        }) {
+            Image(systemName: "plus")
+        })
+            .sheet(isPresented: $isShowingSheet) {
+                VStack() {
+                    Text("Hello Sheet")
+                    Button(action: {
+                        self.isShowingSheet = false
+                    }) { Text("Done")}
+                }
+        }
     }
 }
 
 struct DetailsView_Previews: PreviewProvider {
     static var previews: some View {
-        DetailsView()
+        NavigationView() {
+            DetailsView()
+        }
     }
 }


### PR DESCRIPTION
## Merge after the following PRs ⚠️
N/A

## What does this PR do? 🔧
This PR introduces a "boilerplate" list where movies will eventually be added.  It also adds a `+` button on the navigation bar which will eventually serve as a place for a user to add a movie to the watchlist. Upon tapping the `+` button, a user modal pops up.

## How should it be manually tested? 🔎
- On the Details (list) screen, verify `Movie Watchlist` is displaying in the navigation bar as well as a `+` button.
- Tap the `+` button and verify that a modal (sheet) slides in from the bottom
-Verify a `Done` button is present on the sheet, tap it and one should be brought back to the `Movie Watch List` screen.

## Any background context you want to provide, or implementation details you want to call out? 📖

I am not too sure about my use of `@State`:

`@State var isShowingSheet = false`

According to Swift documentation:

> _"SwiftUI manages the storage of any property you declare as a state. When the state value changes, the view invalidates its appearance and recomputes the body. Use the state as the single source of truth for a given view."_

I am open to suggestions or an alternative approach to handle the toggling/state of the sheet.

## Screenshots/GIFs 📸
![2020-09-09 13 53 57](https://user-images.githubusercontent.com/42355058/92635525-fb6c6f00-f2a3-11ea-9fb8-ef7212abeaf6.gif)
